### PR TITLE
feat: add global ENABLE_BACKGROUND_TASKS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,13 @@ The enhanced `setup-ai-tools.sh` script provides:
 | Anthropic Claude | `claude` | `ANTHROPIC_API_KEY` | [console.anthropic.com](https://console.anthropic.com/) |
 | Google Gemini | `gemini` | `GOOGLE_AI_API_KEY` | [aistudio.google.com/app/apikey](https://aistudio.google.com/app/apikey) |
 | OpenAI Codex | `codex` | `OPENAI_API_KEY` | [platform.openai.com/api-keys](https://platform.openai.com/api-keys) |
+| Background Tasks | `claude` | `ENABLE_BACKGROUND_TASKS` | Set to `1` to enable enhanced processing |
+
+### 🔧 Background Tasks
+
+The setup script automatically configures `ENABLE_BACKGROUND_TASKS=1` for enhanced Claude capabilities:
+- ✅ Adds to shell config (bash/zsh/fish agnostic) for global availability
+- ✅ Prevents duplicates if already configured
 
 ## 🛠️ Available Commands
 

--- a/setup-ai-tools.sh
+++ b/setup-ai-tools.sh
@@ -719,6 +719,14 @@ setup_openai_key() {
     fi
 }
 
+# Setup ENABLE_BACKGROUND_TASKS environment variable
+setup_background_tasks() {
+    print_status "Setting up background tasks support for enhanced Claude capabilities"
+    add_to_shell_config "ENABLE_BACKGROUND_TASKS" "1"
+    export ENABLE_BACKGROUND_TASKS="1"
+    print_success "Background tasks enabled for enhanced Claude processing"
+}
+
 # Display completion message and aliases
 show_completion_message() {
     local shell_config=$(get_shell_config)
@@ -1178,6 +1186,7 @@ main() {
     setup_anthropic_key
     setup_google_key
     setup_openai_key
+    setup_background_tasks
 
     # Handle alias migrations
     handle_alias_migrations


### PR DESCRIPTION
## Summary
- Add global `ENABLE_BACKGROUND_TASKS=1` configuration to enhance Claude Code capabilities
- Integrates cleanly with existing setup script API key configuration pattern
- Shell-agnostic support (bash/zsh/fish)

## Changes Made
- Added `setup_background_tasks()` function in setup-ai-tools.sh
- Updated README.md API keys table and documentation
- Uses existing `add_to_shell_config()` pattern for consistency
- Global configuration only - does not pollute project .env files

## Test Plan
- [x] Function tested in isolation and works correctly
- [x] Follows existing shell detection and configuration patterns
- [x] Adds to appropriate shell config file (.zshrc, .bashrc, etc.)
- [x] Prevents duplicate entries if already configured

🤖 Generated with [Claude Code](https://claude.ai/code)